### PR TITLE
Support multiple categories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.dat
 *.md
 *.pdf
+*.pyomo.soln
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/docs/format.rst
+++ b/docs/format.rst
@@ -1,5 +1,11 @@
+Input formats
+-------------
+
+Supported inputs are markdown files (`.md`).
+
+
 Task list format
-----------------
+================
 
 The basic format is:
 
@@ -42,3 +48,19 @@ Not yet supported
 - In: location
 - Deadline: date/time
 - Deadline?: date/time (uncertain deadline)
+
+Categories
+==========
+
+Privileged categories (not yet supported)
+
+- Work
+- Break
+- Lunch
+- Dinner
+- Errands
+- Sleep
+- Social
+- Outreach/service
+- Me
+- Wellbeing

--- a/scripts/calendar_md.py
+++ b/scripts/calendar_md.py
@@ -24,7 +24,7 @@ tasks = TaskParser(time_allocation_fname, tasks_fname)
 task_names = list(tasks.tasks.keys())
 num_work_tasks = len(task_names)
 
-category_names = list(tasks.time_alloc.keys())[:2]
+category_names = list(tasks.time_alloc.keys())
 task_names += category_names
 
 for i, task in enumerate(task_names):
@@ -53,8 +53,8 @@ for i, cat in enumerate(category_names):
     if 'total' in tasks.time_alloc[cat]:
         category_min[i] = tasks.time_alloc[cat]['total'] * tutil.SLOTS_PER_HOUR
 
-# work_category = category_names.index("Work")
-work_category = 0  # FIXME override
+work_category = category_names.index("Work")
+# work_category = 0  # FIXME override
 work_tasks = range(num_work_tasks)
 task_category[work_tasks, work_category] = 1
 for i in range(num_categories):

--- a/scripts/calendar_md.py
+++ b/scripts/calendar_md.py
@@ -24,7 +24,7 @@ tasks = TaskParser(time_allocation_fname, tasks_fname)
 task_names = list(tasks.tasks.keys())
 num_work_tasks = len(task_names)
 
-category_names = list(tasks.time_alloc.keys())[:10]
+category_names = list(tasks.time_alloc.keys())[:2]
 task_names += category_names
 
 for i, task in enumerate(task_names):
@@ -53,7 +53,8 @@ for i, cat in enumerate(category_names):
     if 'total' in tasks.time_alloc[cat]:
         category_min[i] = tasks.time_alloc[cat]['total'] * tutil.SLOTS_PER_HOUR
 
-work_category = category_names.index("Work")
+# work_category = category_names.index("Work")
+work_category = 0  # FIXME override
 work_tasks = range(num_work_tasks)
 task_category[work_tasks, work_category] = 1
 for i in range(num_categories):

--- a/scripts/calendar_md.py
+++ b/scripts/calendar_md.py
@@ -62,9 +62,9 @@ for i in range(num_categories):
 print("Task category", task_category)
 
 # FIXME(cathywu) have non-uniform utilities
-utilities = np.ones((num_timeslots, num_tasks, num_categories))
+utilities = np.ones((num_timeslots, num_tasks))
 # Fewer points for scheduling default tasks
-utilities[:, num_work_tasks:, :] = 0.5  # TODO parameterize this
+utilities[:, num_work_tasks:] = 0.5  # TODO parameterize this
 
 # Working hours
 # TODO(cathywu) remove this for full scheduling version

--- a/scripts/calendar_md.py
+++ b/scripts/calendar_md.py
@@ -30,8 +30,19 @@ task_chunk_min = DEFAULT_CHUNK_MIN * np.ones(num_tasks)
 #  off by default
 task_chunk_max = DEFAULT_CHUNK_MAX * np.ones(num_tasks)
 
+# FIXME(cathywu) this is temporary for initially supporting categories
+num_categories = 1
+category_names = ["work"]
+
+# num_tasks-by-num_categories matrix
+task_category = np.zeros((num_tasks, num_categories))
+# FIXME(cathywu) this is temporary for initially supporting categories
+task_category[:, 0] = 1
+category_min = np.array([33,])
+category_max = np.array([300,])
+
 # FIXME(cathywu) have non-uniform utilities
-utilities = np.ones((num_tasks, num_timeslots)).T
+utilities = np.ones((num_timeslots, num_tasks, num_categories))
 
 # Working hours
 # TODO(cathywu) remove this for full scheduling version
@@ -112,8 +123,13 @@ for i in range(num_tasks):
 
 # Prepare the IP
 params = {
-    'num_tasks': num_tasks,
     'num_timeslots': num_timeslots,
+    'num_categories': num_categories,
+    'category_names': category_names,
+    'category_min': category_min,
+    'category_max': category_max,
+    'task_category': task_category,
+    'num_tasks': num_tasks,  # for category "work", privileged category 0
     'task_duration': task_duration,
     'task_valid': overall_mask,
     'task_chunk_min': task_chunk_min,

--- a/timealloc/task_parser.py
+++ b/timealloc/task_parser.py
@@ -50,8 +50,10 @@ class TaskParser:
                 for level2 in top.next.next.children:
                     if not isinstance(level2, NavigableString):
                         # print('Category:', level2.next)
-                        m = re.search('(.+) \[([\.\d]+)\].*', level2.next)
+                        m = re.search('(.+) \[([-\.\d]+)\].*', level2.next)
                         category = m.group(1)
+                        total = m.group(2).split('-')
+
                         total = float(m.group(2))
 
                         if category not in self.time_alloc:

--- a/timealloc/task_parser.py
+++ b/timealloc/task_parser.py
@@ -50,18 +50,21 @@ class TaskParser:
                 for level2 in top.next.next.children:
                     if not isinstance(level2, NavigableString):
                         # print('Category:', level2.next)
-                        m = re.search('(.+) \[([-\.\d]+)\].*', level2.next)
+                        m = re.search('(.+) \[([ .,\d]+)\].*', level2.next)
                         category = m.group(1)
-                        total = m.group(2).split('-')
-
-                        total = float(m.group(2))
+                        total = m.group(2).split(', ')
 
                         if category not in self.time_alloc:
                             self.time_alloc[category] = {}
                         self.time_alloc[category]['tag'] = tag
-                        self.time_alloc[category]['total'] = total
-                        self.tags[tag]['total'] += total
-                        self.running_total += total
+
+                        self.time_alloc[category]['total'] = float(total[0])
+                        self.time_alloc[category]['min'] = float(total[0])
+                        if len(total) > 1:
+                            self.time_alloc[category]['max'] = float(total[1])
+
+                        self.tags[tag]['total'] += float(total[0])
+                        self.running_total += float(total[0])
                     if isinstance(level2.next.next, NavigableString):
                         # print('Extra:', level2.next.next)
                         continue
@@ -108,7 +111,7 @@ class TaskParser:
                                             'constraints'].append(datum)
 
                             else:
-                                self.time_alloc[category][label] = metadatum
+                                self.time_alloc[category][label] = metadata
 
                         if isinstance(level3.next.next, NavigableString):
                             # print('Extra:', level2.next.next)

--- a/timealloc/util_time.py
+++ b/timealloc/util_time.py
@@ -138,3 +138,24 @@ def datetime_to_slot_mask(time, modifier="before", duration=None):
         raise (
             NotImplementedError, "Modifier {} not supported".format(modifier))
     return mask
+
+
+def modifier_mask(string, modifier, total):
+    sub_mask = np.zeros(24 * 7 * SLOTS_PER_HOUR)
+    attributes = string.split('; ')
+    for attr in attributes:
+        # print(task, key, attr)
+        try:
+            stime = text_to_struct_time(attr)
+            mask = struct_time_to_slot_mask(stime, modifier=modifier,
+                                            duration=hour_to_ip_slot(total))
+        except UnboundLocalError:
+            try:
+                dtime = text_to_datetime(attr, weekno=39, year=2018)
+                mask = datetime_to_slot_mask(dtime, modifier=modifier,
+                                             duration=hour_to_ip_slot(total))
+            except UnboundLocalError:
+                raise (NotImplementedError,
+                       "{} {} not supported".format(modifier, attr))
+        sub_mask = np.logical_or(sub_mask, mask)
+    return sub_mask


### PR DESCRIPTION
- Support multiple categories, necessary for full IP formulation (see #17)
- Added category duration range constraints
- Added default task for each category, at a lower utility than actual tasks. This permits pad the assignment to meet the minimum allocation for the category. Resolves #54.
- Supports category specific time masks. Resolves #56.
- Supports category ranges. Resolves #55.
- Added spread to objective function
- Refactoring of mask generation code
- Added preliminary documentation for categories
- cleanup and refactoring

Produces a schedule like: https://github.com/cathywu/TimeAlloc/issues/54#issuecomment-425306681